### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,5 +8,5 @@ SimpleDrawing = "d78a06e8-ae74-583c-9a07-0d6572347000"
 
 [compat]
 julia = "1"
-SimpleDrawing = "0"
+SimpleDrawing = "0.0.1, 0.1, 0.2"
 Plots = "1"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman